### PR TITLE
Fix setup's path message

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -2,7 +2,7 @@
 
 echo "starting setup..."
 
-echo "Adding the relative path: $(pwd). Don't change this repository path, or it will not works more!"
+echo "Adding the relative path: $(pwd). Do NOT change this repository path! It will NOT work anymore!"
 
 echo "\n" >> ~/.bashrc
 


### PR DESCRIPTION
## Changes
- Fix setup's path message grammar error
- Remove abbreviation to emphasize the risk of changing the repositoy's path